### PR TITLE
Force utf-8 encoding

### DIFF
--- a/AC_USB_PowerMeter.py
+++ b/AC_USB_PowerMeter.py
@@ -232,7 +232,7 @@ class AC_USB_PM_GUI():
 			if self.RecName == '':
 				self.RecName = 'REC_'+strftime('%Y%m%d%H%M%S',localtime())+'.csv'
 				try:
-					self.f = open(self.RecName,'w')
+					self.f = open(self.RecName,'w',encoding='utf-8')
 					self.f.write('Time[S],')
 					for fd in self.FD: self.f.write(fd.Label+'['+fd.Unit+'],')
 					self.f.write('xmode\n')


### PR DESCRIPTION
An exception 'UnicodeEncodeError: 'charmap' codec can't encode characters' is thrown and an error `can't create `REC_*.csv`` file is shown on non-utf-8 terminals otherwise.